### PR TITLE
Fix CodeMirror theme selector

### DIFF
--- a/src/components/CodeMirror/theme.ts
+++ b/src/components/CodeMirror/theme.ts
@@ -83,7 +83,7 @@ const theme = EditorView.theme(
     ".cm-cursor, .cm-dropCursor": {
       borderLeftColor: caret,
     },
-    "&.cm-focused .cm-selectionBackgroundm .cm-selectionBackground, .cm-content ::selection":
+    "&.cm-focused .cm-selectionBackground, .cm-content::selection":
       {
         backgroundColor: selection,
       },


### PR DESCRIPTION
## Summary
- correct the CSS selector in the CodeMirror theme

## Testing
- `yarn test` *(fails: No tests found)*