### PR TITLE
Add duplication and reset features

### DIFF
--- a/src/components/PreloadedJS/PreloadedJS.module.scss
+++ b/src/components/PreloadedJS/PreloadedJS.module.scss
@@ -8,3 +8,8 @@
     box-shadow: 0 0 0 1px var(--accent), 0 1px 0 1px var(--accent);
   }
 }
+
+.header {
+  display: flex;
+  padding: 4px;
+}

--- a/src/components/PreloadedJS/PreloadedJS.tsx
+++ b/src/components/PreloadedJS/PreloadedJS.tsx
@@ -4,6 +4,8 @@ import useDispatch from "context/useDispatch";
 import styles from "./PreloadedJS.module.scss";
 import useSelector from "context/useSelector";
 import { PRELOADED_JS_ID } from "context/constants";
+import CircleButton from "components/ui/CircleButton";
+import Reload from "icons/Reload";
 import Box from "components/ui/Box";
 
 const PreloadedJS: FC = () => {
@@ -12,6 +14,14 @@ const PreloadedJS: FC = () => {
 
   return (
     <Box>
+      <div className={styles.header}>
+        <CircleButton
+          color="rgb(255, 188, 54)"
+          onClick={() => dispatch({ type: "RESET_PRELOADED_JS" })}
+        >
+          <Reload />
+        </CircleButton>
+      </div>
       <div className={styles.content}>
         <CodeMirror
           id={PRELOADED_JS_ID}

--- a/src/components/TestCase/TestCaseSidebar.tsx
+++ b/src/components/TestCase/TestCaseSidebar.tsx
@@ -4,6 +4,7 @@ import Input from "components/ui/Input";
 import useDispatch from "context/useDispatch";
 import Close from "icons/Close";
 import Reload from "icons/Reload";
+import Duplicate from "icons/Duplicate";
 import useLanguageServer from "languageServer/useLanguageServer";
 import { FC } from "react";
 import useRuntimeContext from "runtime/useRuntimeContext";
@@ -55,6 +56,12 @@ const TestCaseSidebar: FC<TestCaseSidebarProps> = ({
             onClick={() => dispatch({ type: "TOGGLE_COLLAPSED", id })}
           >
             <Close />
+          </CircleButton>
+          <CircleButton
+            color="rgb(120, 120, 255)"
+            onClick={() => dispatch({ type: "DUPLICATE_CASE", id })}
+          >
+            <Duplicate />
           </CircleButton>
           <CircleButton color="rgb(36, 228, 45)" onClick={() => run(id)}>
             <Reload />

--- a/src/context/Provider.tsx
+++ b/src/context/Provider.tsx
@@ -2,12 +2,12 @@ import { FC, PropsWithChildren, useMemo, useReducer } from "react";
 import Context, { State, GetStateContext } from "./context";
 import reducer from "./reducer";
 import useCallbackRef from "hooks/useCallbackRef";
+import { DEFAULT_PRELOADED_JS } from "./constants";
 
 const initialState: State = {
   runningCases: new Set(),
   collapsedCases: new Set(),
-  preloadedJS:
-    "const nums = new Array(1000).fill(null).map(() => Math.random())",
+  preloadedJS: DEFAULT_PRELOADED_JS,
   preloadedJSError: null,
   testCases: [
     {

--- a/src/context/constants.ts
+++ b/src/context/constants.ts
@@ -1,1 +1,4 @@
 export const PRELOADED_JS_ID = "preloadedJS";
+
+export const DEFAULT_PRELOADED_JS =
+  "const nums = new Array(1000).fill(null).map(() => Math.random())";

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -4,6 +4,7 @@ import { State } from "./context";
 import { Action, ExecutionError } from "./types";
 import { assertNever } from "utils/typeguards";
 import { toObject, toString } from "utils/cast";
+import { DEFAULT_PRELOADED_JS } from "./constants";
 
 const formatError = (error: unknown): ExecutionError => {
   const { stack, message } = toObject(error);
@@ -54,6 +55,12 @@ const reducer = (state: State, action: Action): State => {
       });
     }
 
+    case "RESET_PRELOADED_JS": {
+      return produce(state, (draft) => {
+        draft.preloadedJS = DEFAULT_PRELOADED_JS;
+      });
+    }
+
     case "ADD_CASE": {
       return produce(state, (draft) => {
         draft.testCases.push({
@@ -88,6 +95,20 @@ const reducer = (state: State, action: Action): State => {
         );
 
         return draft;
+      });
+    }
+
+    case "DUPLICATE_CASE": {
+      const { id } = action;
+      return produce(state, (draft) => {
+        const existing = draft.testCases.find((t) => t.id === id);
+        if (existing) {
+          draft.testCases.push({
+            id: v4(),
+            title: `${existing.title} copy`,
+            code: existing.code,
+          });
+        }
       });
     }
 

--- a/src/context/types.ts
+++ b/src/context/types.ts
@@ -38,8 +38,17 @@ export type EditPreloadedJSAction = {
   preloadedJS: string;
 };
 
+export type ResetPreloadedJSAction = {
+  type: "RESET_PRELOADED_JS";
+};
+
 export type DeleteTestCaseAction = {
   type: "DELETE_CASE";
+  id: string;
+};
+
+export type DuplicateTestCaseAction = {
+  type: "DUPLICATE_CASE";
   id: string;
 };
 
@@ -72,10 +81,12 @@ export type Action =
   | AddTestCaseAction
   | EditTestCaseAction
   | DeleteTestCaseAction
+  | DuplicateTestCaseAction
   | ToggleRunningAction
   | ReceiveResultsAction
   | StopAllAction
   | EditPreloadedJSAction
+  | ResetPreloadedJSAction
   | ReceiveErrorAction
   | ToggleCollapsed;
 

--- a/src/icons/Duplicate.tsx
+++ b/src/icons/Duplicate.tsx
@@ -1,0 +1,10 @@
+import { FC } from "react";
+
+const Duplicate: FC = () => (
+  <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+    <path d="M1 1h4v4H1V1z" fill="currentColor" />
+    <path d="M3 3h4v4H3V3z" stroke="currentColor" />
+  </svg>
+);
+
+export default Duplicate;


### PR DESCRIPTION
## Summary
- allow resetting preloaded script to the default code
- add button to duplicate test cases
- wire up new actions in context reducer
- provide icon for duplication

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*